### PR TITLE
vscode sidebar に url を入力できるようにする

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,25 @@
         "command": "local-ogp-checker.helloWorld",
         "title": "Hello World"
       }
-    ]
+    ],
+    "views": {
+      "local-ogp-checker-view": [
+        {
+          "type": "webview",
+          "id": "local-ogp-checker.view",
+          "name": "Local OGP Checker 1"
+        }
+      ]
+    },
+    "viewsContainers": {
+      "activitybar": [
+        {
+          "id": "local-ogp-checker-view",
+          "title": "Local OGP Checker",
+          "icon": "resources/icon.svg"
+        }
+      ]
+    }
   },
   "scripts": {
     "vscode:prepublish": "npm run package",

--- a/resources/icon.svg
+++ b/resources/icon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 16 16"><path fill="currentColor" fill-rule="evenodd" d="M14.5 1h-13l-.5.5v3l.5.5H2v8.5l.5.5h11l.5-.5V5h.5l.5-.5v-3zm-1 3H2V2h12v2zM3 13V5h10v8zm8-6H5v1h6z" clip-rule="evenodd"/></svg>

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,13 +1,19 @@
 import * as vscode from 'vscode';
+import { LocalOgpCheckerViewProvider } from './view/LocalOgpCheckerViewProvider';
 
 export function activate(context: vscode.ExtensionContext) {
 	console.log('Congratulations, your extension "local-ogp-checker" is now active!');
 
-	const disposable = vscode.commands.registerCommand('local-ogp-checker.helloWorld', () => {
+	const commandDisposable = vscode.commands.registerCommand('local-ogp-checker.helloWorld', () => {
 		vscode.window.showInformationMessage('Hello World from local-ogp-checker!');
 	});
 
-	context.subscriptions.push(disposable);
+	const localOgpCheckerViewProvider = new LocalOgpCheckerViewProvider(context.extensionUri);
+	const providerDisposable = vscode.window.registerWebviewViewProvider('local-ogp-checker.view', localOgpCheckerViewProvider);
+
+
+	context.subscriptions.push(commandDisposable);
+	context.subscriptions.push(providerDisposable);
 }
 
-export function deactivate() {}
+export function deactivate() { }

--- a/src/view/LocalOgpCheckerViewProvider.ts
+++ b/src/view/LocalOgpCheckerViewProvider.ts
@@ -1,0 +1,55 @@
+import * as vscode from 'vscode';
+
+export class LocalOgpCheckerViewProvider implements vscode.WebviewViewProvider {
+    private _view?: vscode.WebviewView;
+
+    constructor(private readonly _extensionUri: vscode.Uri) { }
+
+    resolveWebviewView(
+        webviewView: vscode.WebviewView,
+        context: vscode.WebviewViewResolveContext,
+        token: vscode.CancellationToken
+    ): Thenable<void> | void {
+        this._view = webviewView;
+
+        webviewView.webview.options = {
+            enableScripts: true,
+        };
+        webviewView.webview.html = this.buildWebviewContent();
+
+        webviewView.webview.onDidReceiveMessage(async (message) => {
+            if (message.command === 'requestOgpCheckSignal') {
+                const siteUrl = message.siteUrl;
+                vscode.window.showInformationMessage(`OGP Check: ${siteUrl}`);
+
+                const response = await fetch(siteUrl);
+                vscode.window.showInformationMessage(`Response: ${response.status}`);
+                vscode.window.showInformationMessage(`Data: ${await response.text()}`);
+            }
+        })
+    }
+
+    private buildWebviewContent(): string {
+        return `
+        <!DOCTYPE html>
+        <html lang="en">
+        <body>
+            <input type="text" id="siteUrl" placeholder="site url" />
+            <button id="button">OGP Check</button>
+
+            <script>
+                const vscode = acquireVsCodeApi();
+                document.getElementById('button').addEventListener('click', () => {
+                    const siteUrl = document.getElementById('siteUrl').value;
+                    vscode.postMessage({
+                        command: 'requestOgpCheckSignal',
+                        siteUrl: siteUrl
+                    });
+                });
+            </script>
+        </body>
+        </html>
+        `;
+    }
+
+}


### PR DESCRIPTION
## 概要

https://zenn.dev/ganariya/scraps/bcc2a2dc96f409
https://zenn.dev/ikoamu/articles/f10441bab57efc#%E3%82%B5%E3%82%A4%E3%83%89%E3%83%A1%E3%83%8B%E3%83%A5%E3%83%BC%E3%81%ABwebview%E3%82%92%E8%A1%A8%E7%A4%BA%E3%81%99%E3%82%8B

VSCode の ActivityBar に URL を入力できるようにします。
また、その URL に GET Request を飛ばし response を取得します。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a dedicated "Local OGP Checker" view in the activity bar
	- Introduced a webview for checking Open Graph Protocol (OGP) data from a specified URL
	- Implemented an interface to input site URLs and trigger OGP checks

- **UI Enhancements**
	- Created a new activity bar entry with a custom icon
	- Added a webview with an input field and check button for URL validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->